### PR TITLE
Fix implicit function declaration of sqrt() function

### DIFF
--- a/lbfgs.cabal
+++ b/lbfgs.cabal
@@ -32,4 +32,4 @@ Library
                   
   C-Sources:            cbits/lbfgs.c
   Include-Dirs:         cbits
-  Includes:             lbfgs.h, arithmetic_ansi.h
+  Includes:             lbfgs.h


### PR DESCRIPTION
Files listed in the `includes` field are included in any compilations via C. But `arithmetic_ansi.h` is only required when compiling `lbfgs.c` and should not be included otherwise.

On some platforms, including `arithmetic_ansi.h` directly causes an error like this:

```
/usr/bin/gcc returned ExitFailure 1 with error message:
In file included from
/var/folders/4f/9nhgxpnx1s9cbc5d5fbffh7m0000gn/T/75100-4.c:2:
./cbits/arithmetic_ansi.h:126:27: error: implicitly declaring library function
'sqrt' with type 'double (double)' [-Werror,-Wimplicit-function-declaration]
*s = (lbfgsfloatval_t)sqrt(*s);
^
./cbits/arithmetic_ansi.h:126:27: note: include the header <math.h> or
explicitly provide a declaration for 'sqrt'
1 error generated.
```