### PR TITLE
Update liblbfgs from 1.9 to 1.10

### DIFF
--- a/cbits/arithmetic_ansi.h
+++ b/cbits/arithmetic_ansi.h
@@ -23,7 +23,7 @@
  * THE SOFTWARE.
  */
 
-/* $Id: arithmetic_ansi.h 65 2010-01-29 12:19:16Z naoaki $ */
+/* $Id$ */
 
 #include <stdlib.h>
 #include <memory.h>

--- a/cbits/arithmetic_sse_double.h
+++ b/cbits/arithmetic_sse_double.h
@@ -23,10 +23,12 @@
  * THE SOFTWARE.
  */
 
-/* $Id: arithmetic_sse_double.h 65 2010-01-29 12:19:16Z naoaki $ */
+/* $Id$ */
 
 #include <stdlib.h>
+#ifndef __APPLE__
 #include <malloc.h>
+#endif
 #include <memory.h>
 
 #if     1400 <= _MSC_VER
@@ -39,10 +41,15 @@
 
 inline static void* vecalloc(size_t size)
 {
-#ifdef	_MSC_VER
+#if     defined(_MSC_VER)
     void *memblock = _aligned_malloc(size, 16);
+#elif   defined(__APPLE__)  /* OS X always aligns on 16-byte boundaries */
+    void *memblock = malloc(size);
 #else
-    void *memblock = memalign(16, size);
+    void *memblock = NULL, *p = NULL;
+    if (posix_memalign(&p, 16, size) == 0) {
+        memblock = p;
+    }
 #endif
     if (memblock != NULL) {
         memset(memblock, 0, size);
@@ -192,7 +199,7 @@ inline static void vecfree(void *memblock)
 
 
 
-#if     3 <= __SSE__
+#if     3 <= __SSE__ || defined(__SSE3__)
 /*
     Horizontal add with haddps SSE3 instruction. The work register (rw)
     is unused.

--- a/cbits/arithmetic_sse_float.h
+++ b/cbits/arithmetic_sse_float.h
@@ -23,10 +23,12 @@
  * THE SOFTWARE.
  */
 
-/* $Id: arithmetic_sse_float.h 65 2010-01-29 12:19:16Z naoaki $ */
+/* $Id$ */
 
 #include <stdlib.h>
+#ifndef __APPLE__
 #include <malloc.h>
+#endif
 #include <memory.h>
 
 #if     1400 <= _MSC_VER
@@ -45,7 +47,16 @@
 
 inline static void* vecalloc(size_t size)
 {
+#if     defined(_MSC_VER)
     void *memblock = _aligned_malloc(size, 16);
+#elif   defined(__APPLE__)  /* OS X always aligns on 16-byte boundaries */
+    void *memblock = malloc(size);
+#else
+    void *memblock = NULL, *p = NULL;
+    if (posix_memalign(&p, 16, size) == 0) {
+        memblock = p;
+    }
+#endif
     if (memblock != NULL) {
         memset(memblock, 0, size);
     }
@@ -185,7 +196,7 @@ inline static void vecfree(void *memblock)
 
 
 
-#if     3 <= __SSE__
+#if     3 <= __SSE__ || defined(__SSE3__)
 /*
     Horizontal add with haddps SSE3 instruction. The work register (rw)
     is unused.

--- a/cbits/lbfgs.c
+++ b/cbits/lbfgs.c
@@ -24,7 +24,7 @@
  * THE SOFTWARE.
  */
 
-/* $Id: lbfgs.c 65 2010-01-29 12:19:16Z naoaki $ */
+/* $Id$ */
 
 /*
 This library is a C port of the FORTRAN implementation of Limited-memory
@@ -65,6 +65,7 @@ licence.
 #include <config.h>
 #endif/*HAVE_CONFIG_H*/
 
+#include <stdint.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <math.h>
@@ -73,7 +74,6 @@ licence.
 
 #ifdef  _MSC_VER
 #define inline  __inline
-typedef unsigned int uint32_t;
 #endif/*_MSC_VER*/
 
 #if     defined(USE_SSE) && defined(__SSE2__) && LBFGS_FLOAT == 64
@@ -290,7 +290,7 @@ int lbfgs(
     if (n % 8 != 0) {
         return LBFGSERR_INVALID_N_SSE;
     }
-    if (((unsigned short)x & 0x000F) != 0) {
+    if ((uintptr_t)(const void*)x % 16 != 0) {
         return LBFGSERR_INVALID_X_SSE;
     }
 #endif/*defined(USE_SSE)*/
@@ -656,8 +656,8 @@ static int line_search_backtracking(
     const lbfgs_parameter_t *param
     )
 {
-    int ret = 0, count = 0;
-    lbfgsfloatval_t width, dg, norm = 0.;
+    int count = 0;
+    lbfgsfloatval_t width, dg;
     lbfgsfloatval_t finit, dginit = 0., dgtest;
     const lbfgsfloatval_t dec = 0.5, inc = 2.1;
 
@@ -749,7 +749,7 @@ static int line_search_backtracking_owlqn(
     const lbfgs_parameter_t *param
     )
 {
-    int i, ret = 0, count = 0;
+    int i, count = 0;
     lbfgsfloatval_t width = 0.5, norm = 0.;
     lbfgsfloatval_t finit = *f, dgtest;
 

--- a/cbits/lbfgs.h
+++ b/cbits/lbfgs.h
@@ -24,7 +24,7 @@
  * THE SOFTWARE.
  */
 
-/* $Id: lbfgs.h 65 2010-01-29 12:19:16Z naoaki $ */
+/* $Id$ */
 
 #ifndef __LBFGS_H__
 #define __LBFGS_H__
@@ -573,7 +573,7 @@ Among the various ports of L-BFGS, this library provides several features:
   The library is thread-safe, which is the secondary gain from the callback
   interface.
 - <b>Cross platform.</b> The source code can be compiled on Microsoft Visual
-  Studio 2005, GNU C Compiler (gcc), etc.
+  Studio 2010, GNU C Compiler (gcc), etc.
 - <b>Configurable precision</b>: A user can choose single-precision (float)
   or double-precision (double) accuracy by changing ::LBFGS_FLOAT macro.
 - <b>SSE/SSE2 optimization</b>:
@@ -592,12 +592,20 @@ This library is used by:
 
 @section download Download
 
-- <a href="http://www.chokkan.org/software/dist/liblbfgs-1.9.tar.gz">Source code</a>
+- <a href="https://github.com/downloads/chokkan/liblbfgs/liblbfgs-1.10.tar.gz">Source code</a>
+- <a href="https://github.com/chokkan/liblbfgs">GitHub repository</a>
 
 libLBFGS is distributed under the term of the
 <a href="http://opensource.org/licenses/mit-license.php">MIT license</a>.
 
 @section changelog History
+- Version 1.10 (2010-12-22):
+    - Fixed compiling errors on Mac OS X; this patch was kindly submitted by
+      Nic Schraudolph.
+    - Reduced compiling warnings on Mac OS X; this patch was kindly submitted
+      by Tamas Nepusz.
+    - Replaced memalign() with posix_memalign().
+    - Updated solution and project files for Microsoft Visual Studio 2010.
 - Version 1.9 (2010-01-29):
     - Fixed a mistake in checking the validity of the parameters "ftol" and
       "wolfe"; this was discovered by Kevin S. Van Horn.
@@ -718,6 +726,7 @@ Special thanks go to:
     - Yoshimasa Tsuruoka and Daisuke Okanohara for technical information about
       OWL-QN
     - Takashi Imamichi for the useful enhancements of the backtracking method
+    - Kevin S. Van Horn, Nic Schraudolph, and Tamas Nepusz for bug fixes
 
 Finally I would like to thank the original author, Jorge Nocedal, who has been
 distributing the effieicnt and explanatory implementation in an open source


### PR DESCRIPTION
This PR updates `liblbfgs` to 1.10 downloaded from https://codeload.github.com/chokkan/liblbfgs/zip/refs/tags/v1.10 .